### PR TITLE
Add build-tree function

### DIFF
--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -368,7 +368,11 @@
     => [{:id 1 :children [{:id 2} {:id 3}]}]
 
   Check test file for more examples."
-  [{:keys [parent-fn] :as opts} items]
+  [{:keys [parent-fn id-fn assoc-children-fn] :as opts} items]
+  (assert parent-fn ":parent-fn option is required.")
+  (assert id-fn ":id-fn option is required.")
+  (assert assoc-children-fn ":assoc-children-fn option is required.")
+
   (let [g (group-by parent-fn items)]
     ;; Start with items which have no parent => root items
     (build-tree' opts g (get g nil))))

--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -332,3 +332,43 @@
   {:added "0.4.0"}
   [& colls]
   (apply map vector colls))
+
+(defn- build-tree' [{:keys [id-fn item-fn children-fn assoc-children-fn]
+                     :or {children-fn identity
+                          item-fn identity}
+                     :as opts}
+                    g
+                    items]
+  (children-fn
+    (map (fn [item]
+           (let [children (build-tree' opts g (get g (id-fn item)))]
+             (item-fn
+               (if (seq children)
+                 (assoc-children-fn item children)
+                 item))))
+         items)))
+
+(defn build-tree
+  "Builds a tree from given items collections.
+
+  ID is what is used to match parents and children.
+  Root items are those where parent-fn returns nil.
+
+  Options:
+
+  - :parent-fn (required) Used to create a map from ID => children
+  - :id-fn (required) Used to get the ID from an item
+  - :assoc-children-fn (required) Attach the children to an item
+  - :item-fn (optional) Called for each item, after children has been attached to the item
+  - :children-fn (optional) Called for each children collection
+
+  Example:
+    (build-tree {:id-fn :id, :parent-fn :parent, :assoc-children-fn #(assoc %1 :children %2)}
+                [{:id 1} {:id 2 :parent 1} {:id 3 :parent 1}])
+    => [{:id 1 :children [{:id 2} {:id 3}]}]
+
+  Check test file for more examples."
+  [{:keys [parent-fn] :as opts} items]
+  (let [g (group-by parent-fn items)]
+    ;; Start with items which have no parent => root items
+    (build-tree' opts g (get g nil))))

--- a/test/potpuri/core_test.cljc
+++ b/test/potpuri/core_test.cljc
@@ -161,3 +161,98 @@
 
 (deftest zip-test
   (is (= [[1 :a] [2 :b] [3 :c]] (p/zip [1 2 3] [:a :b :c]))))
+
+(deftest build-tree-test
+  (testing "Basic case, depth 1"
+    (is (= [{:id 1
+             :parent nil
+             :children [{:id 2 :parent 1}
+                        {:id 3 :parent 1}]}]
+           (p/build-tree
+             {:id-fn :id
+              :parent-fn :parent
+              :assoc-children-fn #(assoc %1 :children %2)}
+             [{:id 1 :parent nil}
+              {:id 2 :parent 1}
+              {:id 3 :parent 1}]))))
+
+  (testing "Basic case, modify items after building tree"
+    (is (= [{:id 1
+             :children [{:id 2}
+                        {:id 3}]}]
+           (p/build-tree
+             {:id-fn :id
+              :parent-fn :parent
+              :item-fn #(dissoc % :parent)
+              :assoc-children-fn #(assoc %1 :children %2)}
+             [{:id 1 :parent nil}
+              {:id 2 :parent 1}
+              {:id 3 :parent 1}]))))
+
+  (testing "Depth 2"
+    (is (= [{:id 1
+             :parent nil
+             :children [{:id 2 :parent 1
+                         :children [{:id 3 :parent 2}]}]}]
+           (p/build-tree
+             {:id-fn :id
+              :parent-fn :parent
+              :children-fn vec
+              :assoc-children-fn #(assoc %1 :children %2)}
+             [{:id 1 :parent nil}
+              {:id 2 :parent 1}
+              {:id 3 :parent 2}]))))
+
+  (testing "Multiple roots"
+    (is (= [{:id 1
+             :parent nil
+             :children [{:id 3 :parent 1}]}
+            {:id 2
+             :parent nil
+             :children [{:id 4 :parent 2}]}]
+           (p/build-tree
+             {:id-fn :id
+              :parent-fn :parent
+              :assoc-children-fn #(assoc %1 :children %2)}
+             [{:id 1 :parent nil}
+              {:id 2 :parent nil}
+              {:id 3 :parent 1}
+              {:id 4 :parent 2}]))))
+
+  (testing "Children as map"
+    (is (= {1 {:id 1
+               :parent nil
+               :children {2 {:id 2 :parent 1}
+                          3 {:id 3 :parent 1}}}}
+           (p/build-tree
+             {:id-fn :id
+              :parent-fn :parent
+              :children-fn #(p/index-by :id %)
+              :assoc-children-fn #(assoc %1 :children %2)}
+             [{:id 1 :parent nil}
+              {:id 2 :parent 1}
+              {:id 3 :parent 1}]))))
+
+  (testing "Duplicate items"
+    (is (= [{:id 1
+             :parent nil
+             :children [{:id 3 :parent 1}
+                        {:id 4 :parent 1}]}
+            {:id 2
+             :parent nil
+             :children [{:id 3 :parent 2}
+                        {:id 4 :parent 2}]}]
+           ;; In this case, user could separate :parents to items with :parent
+           (p/build-tree
+             {:id-fn :id
+              :parent-fn :parent
+              :assoc-children-fn #(assoc %1 :children %2)}
+             (mapcat (fn [item]
+                       (if (seq (:parents item))
+                         (map #(-> item (dissoc :parents) (assoc :parent %)) (:parents item))
+                         [(-> item (dissoc :parents) (assoc :parent nil))]))
+                     [{:id 1 :parents nil}
+                      {:id 2 :parents nil}
+                      {:id 3 :parents [1 2]}
+                      {:id 4 :parents [1 2]}])))))
+  )


### PR DESCRIPTION
Created together with @tkataja, should currently fulfill needs of at least two projects.

Can someone think of other use cases which should be tested, or better names for parameters.
All options now end with `-fn` which is probably bit unnecessary.
Options should also be validated (asserted that required options are given).