### PR TITLE
Make create-predicate public

### DIFF
--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -139,7 +139,7 @@
               :cljs "assoc expects even number of arguments after map/vector, found odd number")))
        ret))))
 
-(defn- create-predicate [where]
+(defn create-predicate [where]
   (cond
     (fn? where)
     where

--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -139,7 +139,17 @@
               :cljs "assoc expects even number of arguments after map/vector, found odd number")))
        ret))))
 
-(defn create-predicate [where]
+(defn create-predicate
+  "Returns a predicate that accepts a value and returns truthy based on `where` argument.
+
+  If `where` is a map, returns a predicate that compares all key/value pairs of `where` to
+  the key/values of the value given to the predicate.
+
+  If `where` is a function (either `fn?` or `ifn?`), returns `where`.
+
+  For all other values of `where` returns a predicate that compares the argument of predicate
+  against `where` using `clojure.core/=`."
+  [where]
   (cond
     (fn? where)
     where

--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -151,9 +151,6 @@
   against `where` using `clojure.core/=`."
   [where]
   (cond
-    (fn? where)
-    where
-
     ; fn? and map? first as map also implements IFn
     (map? where)
     (fn [v]

--- a/test/potpuri/core_test.cljc
+++ b/test/potpuri/core_test.cljc
@@ -89,6 +89,22 @@
   (is (= (p/assoc-if {:a 5} :a nil) {:a 5}))
   (is (= (p/assoc-if {} :a 1 :b false :c 2) {:a 1 :b false :c 2})))
 
+(deftest create-predicate-test
+  (testing "fn?'s are returned as is"
+    (let [f (constantly true)]
+      (is (identical? f (p/create-predicate f)))))
+
+  (testing "ifn?'s are returned as is"
+    (is (= :foo (p/create-predicate :foo)))
+    (is (= #{42} (p/create-predicate #{42}))))
+
+  (testing "map predicates"
+    (let [p (p/create-predicate {:foo 42})]
+      (is (= (p {:foo 42}) true))
+      (is (= (p {:foo 42
+                 :bar 1337}) true))
+      (is (= (p {:bar 1337}) false)))))
+
 (deftest conjv-test
   (is (= (p/conjv [1 2] 3) [1 2 3]))
   (is (= (update-in {:a [1 2]} [:a] p/conjv 3) {:a [1 2 3]}))


### PR DESCRIPTION
As the create-predicate is pretty useful in itself, this PR makes it public.