### PR TITLE
Make index-by use transducers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,14 +21,14 @@
 
   :profiles {:dev {:plugins [[jonase/eastwood "0.2.1"]]
                    :dependencies [[org.clojure/clojure "1.9.0"]
-                                  [criterium "0.4.4"]
-                                  [org.clojure/clojurescript "1.10.439"]]}
+                                  [criterium "0.4.5"]
+                                  [org.clojure/clojurescript "1.10.520"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]
                                   ;; Test aren't run with old cljs - but new cljs would bring in
                                   ;; new tools.reader which doesn't work with old Clojure.
                                   [org.clojure/clojurescript "1.7.228"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.10 {:dependencies  [[org.clojure/clojure "1.10.0-RC2"]]}}
+             :1.10 {:dependencies  [[org.clojure/clojure "1.10.0"]]}}
   :deploy-repositories [["releases" :clojars]]
   :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.10"]
             "test-clj"  ["all" "do" ["bat-test"] ["check"]]})

--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -360,7 +360,7 @@
   {:added "0.3.0"}
   [f coll]
   ; FIXME: perf test against reduce+transient and zipmap
-  (into {} (map (juxt f identity) coll)))
+  (into {} (map (juxt f identity)) coll))
 
 (defn zip
   "Returns a sequence of vectors where the i-th vector contains


### PR DESCRIPTION
It's a bit faster and probably allocates less as well.