### PR TITLE
simplify map-of

### DIFF
--- a/src/potpuri/core.cljc
+++ b/src/potpuri/core.cljc
@@ -74,7 +74,7 @@
    symbol values as values."
   {:added "0.1.0"}
   [& syms]
-  `(zipmap ~(vec (map keyword syms)) ~(vec syms)))
+  (zipmap (map keyword syms) syms))
 
 (defn deep-merge
   "Recursively merges maps.


### PR DESCRIPTION
`map-of` can macroexpand to a map literal instead of a zipmap call—if you prefer!

source: https://stackoverflow.com/a/11705723/142317  (from @omriBernstein)